### PR TITLE
[Issue Fix] Move the temporary UV space off of window.uv

### DIFF
--- a/app/design/frontend/base/default/template/qubit/uv.phtml
+++ b/app/design/frontend/base/default/template/qubit/uv.phtml
@@ -7,8 +7,10 @@ $uv = $helper->getUv();
 
 <?php if ($helper->uvEnabled()): ?>
     <script type="text/javascript">
-        var uv = <?php echo $uv->getUvData(); ?>;
-        window.universal_variable = $H(window.universal_variable || {}).merge(uv).toObject();
+      (function () {
+        var uvTemp = <?php echo $uv->getUvData(); ?>;
+        window.universal_variable = $H(window.universal_variable || {}).merge(uvTemp).toObject();
+      })();
     </script>
 <?php endif;?>
 <?php if ($helper->opentagEnabled()): ?>


### PR DESCRIPTION
This is down to Qubit internal services now using window.uv

It is now mapped to: window.magento_uv_temp